### PR TITLE
Game empty state, and Player's online props

### DIFF
--- a/routes/game.js
+++ b/routes/game.js
@@ -8,17 +8,7 @@ const router = express.Router();
 const { generateID, handleError } = require("../utils");
 
 router.get("/test", async (req, res) => {
-  const game = await Game.findById("Ay513wY8St");
-  game.pwhite = game.user0;
-  game.pblack = game.user1;
-  game.updateChessData({
-    fen: "lalala",
-    turn: "b",
-    board: [2, 3, 4, 5],
-    moves: [{ a: "e4", 2: "e5" }],
-  });
-  await game.save();
-  res.json(game);
+  res.json({ success: "/game/test successful" });
 });
 
 router.post("/new", async (req, res) => {

--- a/routes/game.js
+++ b/routes/game.js
@@ -87,15 +87,6 @@ router.post("/:id/leave", async (req, res) => {
     const game = await Game.findById(id);
     if (!game) throw "404/game not found";
 
-    if (game.state === "waiting") {
-      if (game.user0.uid !== uid) {
-        throw "403/user is not in the game";
-      }
-      // game is empty
-      await game.delete();
-      return res.json({ success: `game ${id} deleted` });
-    }
-
     await game.leaveUid(uid);
     res.json(game);
   } catch (error) {
@@ -110,7 +101,7 @@ router.post("/:id/ready", async (req, res) => {
   try {
     const game = await Game.findById(id);
     if (!game) throw "404/game not found";
-    if (game.user1.uid !== uid) throw "403/only user1 can toggle ready";
+    if (game.user1.uid !== uid) throw "403/only challenger can toggle ready";
 
     await game.toggleReady();
     res.json(game);
@@ -127,7 +118,7 @@ router.post("/:id/start", async (req, res) => {
     const game = await Game.findById(id);
     if (!game) throw "404/game not found";
     if (game.state !== "ready") throw "403/game state must be ready";
-    if (game.user0.uid !== uid) throw "403/only user0 can start the game";
+    if (game.user0.uid !== uid) throw "403/only game owner can start the game";
 
     await game.startGame();
     res.json(game);


### PR DESCRIPTION
**Problem**: whenever a user/player disconnects/leave the <Game /> page, they will emit a "leave" signal to the server, which then will delete the game if the game is empty after they leave. While this sounds somewhat convenient, it can cause some problems. For example, if a player that just created a room and still waiting for another player to join (game.state === "waiting") disconnected (because of reasons, like internet connection). By the time they reconnect, there will be an error because the game already got deleted after the server noticed that the game is empty.

**Solution**: Don't delete the game immediately when it's empty. Instead, make an "empty" state for game with no player, and make mongoose periodically delete all "empty" game that has passed some time, like 24 hours.

**Addition**: When the game starts and beyond (game "playing" or "ended"), we don't change the value of user0 and user1 anymore. They are locked for the rest of their life. Instead, we now look at pwhite and pblack (players) and modify their "online" props to true/false depending on if they join/leave during the game